### PR TITLE
Make the DNS view customizable by the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ spec:
   disableTLSVerification: true      # disable TLSVerification
   customCAPath: "/some/path/ca.crt" # path to a file which contians list of custom Certificate Authorities that can be used to verify SSL certifcates if 'disableTLSVerification' is set to 'false'. Host's default authorities will be used if not specified.
   defaultNetworkView: "some-view"   # default network view
+  defaultDnsView: "some-dns-view"   # <--- NEW: default DNS view
   wapiVersion: "2.12"               # Web API Version of the Infoblox server
 ```
 
@@ -74,10 +75,14 @@ spec:
   instance:
     name: "production"              # name of the InfobloxInstance
   networkView: "datacenter-network" # Infoblox network view that will be used
+  dnsView: "some-dns-view"          # <--- NEW: DNS view for this pool (optional)
   subnets:                          # list of the subnets in the network view we want to get IP addresses from
     - cidr: "10.0.0.0/24"           # subnet CIDR
       gateway: "10.0.0.1"           # gateway that should ba assigned to the IP Address claim
 ```
+
+- If `dnsView` is not set, the pool will inherit the `defaultDnsView` from the referenced InfobloxInstance.
+- If neither is set, the provider will use the Infoblox default DNS view.
 
 Now, whenever `IPAddressClaim` that references `example-pool` will be created, a host record will be created in the subnet specified by the pool on the InfobloxInstance `production` to allocate an IP Address.
 
@@ -98,7 +103,7 @@ We've currently only implemented one strategy for identifying the hostname of a 
 
 Our strategy uses the name of the CAPI `Machine` as the hostname. To determine the Machine name the provider follows the owner chain from the `IPAddressClaim` via the infrastructure provider resources to the `Machine`. This is used by searching through the owner references up to a depth of five.
 
-To enable setting DNS entries, set the `spec.dnsZone` parameter on the `InfobloxIPPool` to your desired zone. The resulting DNS entries will then be `<machine name>.<dnsZone>`. The DNS view will be set to `default.<dnsZone>`.
+To enable setting DNS entries, set the `spec.dnsZone` parameter on the `InfobloxIPPool` to your desired zone. The resulting DNS entries will then be `<machine name>.<dnsZone>`. The DNS view will be set to the value of `dnsView` (or `defaultDnsView` if not set).
 
 ## Running Tests
 

--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -21,6 +21,8 @@ const (
 	AuthenticationFailedReason = "AuthenticationFailed"
 	// NetworkViewNotFoundReason indicates that the specified network view could not be found on the Infoblox instance.
 	NetworkViewNotFoundReason = "NetworkViewNotFound"
+	// DnsViewNotFoundReason indicates that the specified DNS view could not be found on the Infoblox instance.
+	DnsViewNotFoundReason = "DnsViewNotFound"
 	// NetworkNotFoundReason indicates that the specified network could not be found on the Infoblox instance.
 	NetworkNotFoundReason = "NetworkNotFound"
 )

--- a/api/v1alpha1/infobloxinstance_types.go
+++ b/api/v1alpha1/infobloxinstance_types.go
@@ -40,6 +40,10 @@ type InfobloxInstanceSpec struct {
 	// InfobloxIPPools will inherit this value when not explicitly specifying a network view.
 	// +optional
 	DefaultNetworkView string `json:"defaultNetworkView,omitempty"`
+	// DefaultDnsView is the default DNS view used when interacting with Infoblox.
+	// InfobloxIPPools will inherit this value when not explicitly specifying a DNS view.
+	// +optional
+	DefaultDnsView string `json:"defaultDnsView,omitempty"`
 	// DisableTLSVerification if set 'true', certificates for SSL commuunication with Infoblox instance will be not verified
 	DisableTLSVerification bool `json:"disableTLSVerification,omitempty"`
 	// CustomCAPath can be used to point Infoblox client to a file with a list of accepted certificate authorities. Only used if DisableTLSVerification is set to 'false'.

--- a/api/v1alpha1/infobloxippool_types.go
+++ b/api/v1alpha1/infobloxippool_types.go
@@ -16,6 +16,9 @@ type InfobloxIPPoolSpec struct {
 	// NetworkView defines Infoblox netwok view to be used with pool.
 	// +optional
 	NetworkView string `json:"networkView,omitempty"`
+	// DnsView defines Infoblox DNS view to be used with pool.
+	// +optional
+	DnsView string `json:"dnsView,omitempty"`
 	// DNSZone is the DNS zone within which hostnames will be allocated.
 	// +optional
 	DNSZone string `json:"dnsZone,omitempty"`

--- a/config/crd/bases/ipam.cluster.x-k8s.io_infobloxinstances.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_infobloxinstances.yaml
@@ -73,6 +73,11 @@ spec:
                   a file with a list of accepted certificate authorities. Only used
                   if DisableTLSVerification is set to 'false'.
                 type: string
+              defaultDnsView:
+                description: |-
+                  DefaultDnsView is the default DNS view used when interacting with Infoblox.
+                  InfobloxIPPools will inherit this value when not explicitly specifying a DNS view.
+                type: string
               defaultNetworkView:
                 description: |-
                   DefaultNetworkView is the default network view used when interacting with Infoblox.

--- a/config/crd/bases/ipam.cluster.x-k8s.io_infobloxippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_infobloxippools.yaml
@@ -48,6 +48,9 @@ spec:
           spec:
             description: InfobloxIPPoolSpec defines the desired state of InfobloxIPPool.
             properties:
+              dnsView:
+                description: DnsView defines Infoblox DNS view to be used with pool.
+                type: string
               dnsZone:
                 description: DNSZone is the DNS zone within which hostnames will be
                   allocated.

--- a/config/samples/infobloxippool.yaml
+++ b/config/samples/infobloxippool.yaml
@@ -10,4 +10,5 @@ spec:
     - cidr: "10.0.0.0/24"
       gateway: "10.0.0.1"
   networkView: "some-view"
+  dnsView: "some-dns-view"
   dnsZone: ""

--- a/internal/controllers/infobloxinstance.go
+++ b/internal/controllers/infobloxinstance.go
@@ -112,6 +112,7 @@ func (r *InfobloxInstanceReconciler) reconcile(ctx context.Context, instance *v1
 		DisableTLSVerification: instance.Spec.DisableTLSVerification,
 		CustomCAPath:           instance.Spec.CustomCAPath,
 		DefaultNetworkView:     instance.Spec.DefaultNetworkView,
+		DefaultDnsView:         instance.Spec.DefaultDnsView,
 	}
 
 	ibcl, err := r.NewInfobloxClientFunc(infoblox.Config{HostConfig: hc, AuthConfig: authConfig})
@@ -133,6 +134,19 @@ func (r *InfobloxInstanceReconciler) reconcile(ctx context.Context, instance *v1
 			clusterv1.ConditionSeverityError,
 			"could not find default network view: %s", err)
 		return ctrl.Result{}, nil
+	}
+
+	// Check DNS view if specified
+	if instance.Spec.DefaultDnsView != "" {
+		if ok, err := ibcl.CheckDnsViewExists(instance.Spec.DefaultDnsView); err != nil || !ok {
+			logger.Error(err, "could not find default DNS view", "dnsView", instance.Spec.DefaultDnsView)
+			conditions.MarkFalse(instance,
+				clusterv1.ReadyCondition,
+				v1alpha1.DnsViewNotFoundReason,
+				clusterv1.ConditionSeverityError,
+				"could not find default DNS view: %s", err)
+			return ctrl.Result{}, nil
+		}
 	}
 
 	conditions.MarkTrue(instance,

--- a/internal/controllers/ipaddressclaim.go
+++ b/internal/controllers/ipaddressclaim.go
@@ -178,7 +178,7 @@ func (h *InfobloxClaimHandler) EnsureAddress(ctx context.Context, address *ipamv
 		}
 
 		var ipaddr netip.Addr
-		ipaddr, err = h.ibclient.GetOrAllocateAddress(h.pool.Spec.NetworkView, subnet, hostName, h.pool.Spec.DNSZone, logger)
+		ipaddr, err = h.ibclient.GetOrAllocateAddress(h.pool.Spec.NetworkView, h.pool.Spec.DnsView, subnet, hostName, h.pool.Spec.DNSZone, logger)
 		if err != nil {
 			continue
 		}
@@ -233,7 +233,7 @@ func (h *InfobloxClaimHandler) ReleaseAddress(ctx context.Context) (*ctrl.Result
 			continue
 		}
 
-		err = h.ibclient.ReleaseAddress(h.pool.Spec.NetworkView, subnet, hostName, logger)
+		err = h.ibclient.ReleaseAddress(h.pool.Spec.NetworkView, h.pool.Spec.DnsView, subnet, hostName, logger)
 		if err != nil {
 			// since ibclient.NotFoundError has a pointer receiver on it's Error() method, we can't use errors.As() here.
 			if _, ok := err.(*ibclient.NotFoundError); !ok {

--- a/internal/controllers/ipaddressclaim_test.go
+++ b/internal/controllers/ipaddressclaim_test.go
@@ -139,8 +139,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 			It("should allocate an Address from the Pool", func() {
 				addr, err := netip.ParseAddr("10.0.0.2")
 				Expect(err).NotTo(HaveOccurred())
-				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
-				localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
+				localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 				claim := newClaim(claimName, namespace, "InfobloxIPPool", poolName)
 				expectedIPAddress = ipamv1.IPAddress{
@@ -195,9 +195,9 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 				Expect(err).NotTo(HaveOccurred())
 				addr, err := netip.ParseAddr("10.0.1.2")
 				Expect(err).NotTo(HaveOccurred())
-				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), subnet0, gomock.Any(), gomock.Any(), gomock.Any()).Return(netip.Addr{}, errors.New("no available addresses")).AnyTimes()
-				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), subnet1, gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
-				localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), subnet0, gomock.Any(), gomock.Any(), gomock.Any()).Return(netip.Addr{}, errors.New("no available addresses")).AnyTimes()
+				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), subnet1, gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
+				localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 				claim := newClaim(claimName, namespace, "InfobloxIPPool", poolName)
 				expectedIPAddress = ipamv1.IPAddress{
@@ -284,8 +284,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 			It("should allocate an Address from the Pool", func() {
 				addr, err := netip.ParseAddr("10.0.0.2")
 				Expect(err).NotTo(HaveOccurred())
-				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
-				localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
+				localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 				claim := newClaim(claimName, namespace, "InfobloxIPPool", poolName)
 				expectedIPAddress = ipamv1.IPAddress{
@@ -411,8 +411,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 				It("should not create an IPAddress for claims until the pool is unpaused", func() {
 					addr, err := netip.ParseAddr("10.0.0.2")
 					Expect(err).NotTo(HaveOccurred())
-					localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
-					localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+					localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
+					localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 					tmpPool := &v1alpha1.InfobloxIPPool{}
 					err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&pool), tmpPool)
@@ -473,8 +473,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 				It("should prevent deletion of claims", func() {
 					addr, err := netip.ParseAddr("10.0.0.2")
 					Expect(err).NotTo(HaveOccurred())
-					localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
-					localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+					localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
+					localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 					claim := newClaim("paused-pool-delete-claim-test", namespace, "InfobloxIPPool", poolName)
 					Expect(k8sClient.Create(context.Background(), &claim)).To(Succeed())
@@ -546,8 +546,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 		It("should add the owner references and finalizer", func() {
 			addr, err := netip.ParseAddr("10.0.0.2")
 			Expect(err).NotTo(HaveOccurred())
-			localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
-			localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
+			localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 			addressSpec := ipamv1.IPAddressSpec{
 				ClaimRef: corev1.LocalObjectReference{
@@ -640,8 +640,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 		It("should add the owner references and finalizer", func() {
 			addr, err := netip.ParseAddr("10.0.0.2")
 			Expect(err).NotTo(HaveOccurred())
-			localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
-			localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
+			localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 			addressSpec := ipamv1.IPAddressSpec{
 				ClaimRef: corev1.LocalObjectReference{
@@ -920,8 +920,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 			It("allocates an ipaddress upon updating a cluster when removing spec.paused", func() {
 				addr, err := netip.ParseAddr("10.0.0.2")
 				Expect(err).NotTo(HaveOccurred())
-				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
-				localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
+				localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 				cluster = clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
@@ -959,8 +959,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 			It("allocates an ipaddress upon updating a cluster when removing the paused annotation", func() {
 				addr, err := netip.ParseAddr("10.0.0.2")
 				Expect(err).NotTo(HaveOccurred())
-				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
-				localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
+				localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 				cluster = clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1066,8 +1066,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 		It("does not allocate an ipaddress for the claim until the ip address claim is unpaused", func() {
 			addr, err := netip.ParseAddr("10.0.0.2")
 			Expect(err).NotTo(HaveOccurred())
-			localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
-			localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(addr, nil).AnyTimes()
+			localInfobloxClientMock.EXPECT().ReleaseAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 			claim := newClaim("test", namespace, "InfobloxIPPool", poolName)
 			claim.ObjectMeta.Annotations = map[string]string{
@@ -1164,7 +1164,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 		})
 
 		It("should not allocate an Address if there are no addresses available", func() {
-			localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(netip.Addr{}, errors.New("no available addresses")).AnyTimes()
+			localInfobloxClientMock.EXPECT().GetOrAllocateAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(netip.Addr{}, errors.New("no available addresses")).AnyTimes()
 
 			claim := newClaim(claimName, namespace, "InfobloxIPPool", poolName)
 

--- a/pkg/infoblox/addresses_test.go
+++ b/pkg/infoblox/addresses_test.go
@@ -36,14 +36,14 @@ var _ = Describe("IP Address Management", func() {
 		})
 		Context("IPv4", func() {
 			It("creates a new host record and allocates an IP", func() {
-				addr, err := testClient.GetOrAllocateAddress(testView, v4subnet1, hostname, "", logger)
+				addr, err := testClient.GetOrAllocateAddress(testView, testView, v4subnet1, hostname, "", logger)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(v4subnet1.Contains(addr)).To(BeTrue())
 			})
 		})
 		Context("IPv6", func() {
 			It("creates a new host record and allocates an IP", func() {
-				addr, err := testClient.GetOrAllocateAddress(testView, v6subnet1, hostname, "", logger)
+				addr, err := testClient.GetOrAllocateAddress(testView, testView, v6subnet1, hostname, "", logger)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(v6subnet1.Contains(addr)).To(BeTrue())
 			})
@@ -81,32 +81,32 @@ var _ = Describe("IP Address Management", func() {
 			})
 
 			It("returns the existing IP if the subnet is the same", func() {
-				addr, err := testClient.GetOrAllocateAddress(testView, v4subnet1, hostname, "", logger)
+				addr, err := testClient.GetOrAllocateAddress(testView, testView, v4subnet1, hostname, "", logger)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(addr.String()).To(BeEquivalentTo(*hostRecord.Ipv4Addrs[0].Ipv4Addr))
 			})
 
 			It("allocates another IP if the subnet is different", func() {
 				Expect(testView).To(Equal(defaultView))
-				addr, err := testClient.GetOrAllocateAddress(testView, v4subnet2, hostname, "", logger)
+				addr, err := testClient.GetOrAllocateAddress(testView, testView, v4subnet2, hostname, "", logger)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(v4subnet2.Contains(addr)).To(BeTrue())
 			})
 
 			It("allocates an IPv6 address if the subnet is IPv6", func() {
-				addr, err := testClient.GetOrAllocateAddress(testView, v6subnet1, hostname, "", logger)
+				addr, err := testClient.GetOrAllocateAddress(testView, testView, v6subnet1, hostname, "", logger)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(v6subnet1.Contains(addr)).To(BeTrue())
 			})
 
 			It("deletes the host record when releasing the address", func() {
-				err := testClient.ReleaseAddress(testView, v4subnet1, hostname, logger)
+				err := testClient.ReleaseAddress(testView, testView, v4subnet1, hostname, logger)
 				Expect(err).NotTo(HaveOccurred())
 				hrDeleted = true
 			})
 
 			It("doesnt change the host record when releasing an address in a different subnet", func() {
-				err := testClient.ReleaseAddress(testView, v4subnet2, hostname, logger)
+				err := testClient.ReleaseAddress(testView, testView, v4subnet2, hostname, logger)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -120,31 +120,31 @@ var _ = Describe("IP Address Management", func() {
 			})
 
 			It("returns the existing IP if the subnet is the same", func() {
-				addr, err := testClient.GetOrAllocateAddress(testView, v6subnet1, hostname, "", logger)
+				addr, err := testClient.GetOrAllocateAddress(testView, testView, v6subnet1, hostname, "", logger)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(addr).To(Equal(netip.MustParseAddr(*hostRecord.Ipv6Addrs[0].Ipv6Addr)))
 			})
 
 			It("allocates another IP if the subnet is different", func() {
-				addr, err := testClient.GetOrAllocateAddress(testView, v6subnet2, hostname, "", logger)
+				addr, err := testClient.GetOrAllocateAddress(testView, testView, v6subnet2, hostname, "", logger)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(v6subnet2.Contains(addr)).To(BeTrue())
 			})
 
 			It("allocates an IPv4 address if the subnet is IPv4", func() {
-				addr, err := testClient.GetOrAllocateAddress(testView, v4subnet1, hostname, "", logger)
+				addr, err := testClient.GetOrAllocateAddress(testView, testView, v4subnet1, hostname, "", logger)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(v4subnet1.Contains(addr)).To(BeTrue())
 			})
 
 			It("deletes the host record when releasing the address", func() {
-				err := testClient.ReleaseAddress(testView, v6subnet1, hostname, logger)
+				err := testClient.ReleaseAddress(testView, testView, v6subnet1, hostname, logger)
 				Expect(err).NotTo(HaveOccurred())
 				hrDeleted = true
 			})
 
 			It("doesnt change the host record when releasing an address in a different subnet", func() {
-				err := testClient.ReleaseAddress(testView, v6subnet2, hostname, logger)
+				err := testClient.ReleaseAddress(testView, testView, v6subnet2, hostname, logger)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -180,7 +180,7 @@ var _ = Describe("IP Address Management", func() {
 			})
 
 			It("keeps the host record when releasing an address", func() {
-				err := testClient.ReleaseAddress(testView, v4subnet1, hostname, logger)
+				err := testClient.ReleaseAddress(testView, testView, v4subnet1, hostname, logger)
 				Expect(err).NotTo(HaveOccurred())
 
 				hostRecord, err := testClient.objMgr.GetHostRecordByRef(hostRecord.Ref)
@@ -212,7 +212,7 @@ var _ = Describe("IP Address Management", func() {
 			})
 
 			It("keeps the host record when releasing an address", func() {
-				err := testClient.ReleaseAddress(testView, v6subnet1, hostname, logger)
+				err := testClient.ReleaseAddress(testView, testView, v6subnet1, hostname, logger)
 				Expect(err).NotTo(HaveOccurred())
 
 				hostRecord, err := testClient.objMgr.GetHostRecordByRef(hostRecord.Ref)
@@ -245,7 +245,7 @@ var _ = Describe("IP Address Management", func() {
 			})
 
 			It("keeps the host record when releasing a v4 address", func() {
-				err := testClient.ReleaseAddress(testView, v4subnet1, hostname, logger)
+				err := testClient.ReleaseAddress(testView, testView, v4subnet1, hostname, logger)
 				Expect(err).NotTo(HaveOccurred())
 
 				hostRecord, err := testClient.objMgr.GetHostRecordByRef(hostRecord.Ref)
@@ -254,7 +254,7 @@ var _ = Describe("IP Address Management", func() {
 			})
 
 			It("keeps the host record when releasing a v6 address", func() {
-				err := testClient.ReleaseAddress(testView, v6subnet1, hostname, logger)
+				err := testClient.ReleaseAddress(testView, testView, v6subnet1, hostname, logger)
 				Expect(err).NotTo(HaveOccurred())
 
 				hostRecord, err := testClient.objMgr.GetHostRecordByRef(hostRecord.Ref)

--- a/pkg/infoblox/client.go
+++ b/pkg/infoblox/client.go
@@ -25,11 +25,13 @@ const (
 // Client is a wrapper around the infoblox client that can allocate and release addresses indempotently.
 type Client interface {
 	// GetOrAllocateAddress allocates an address for a given hostname if none exists, and returns the new or existing address.
-	GetOrAllocateAddress(view string, subnet netip.Prefix, hostname, zone string, logger logr.Logger) (netip.Addr, error)
+	GetOrAllocateAddress(networkView, dnsView string, subnet netip.Prefix, hostname, zone string, logger logr.Logger) (netip.Addr, error)
 	// ReleaseAddress releases an address for a given hostname.
-	ReleaseAddress(view string, subnet netip.Prefix, hostname string, logger logr.Logger) error
+	ReleaseAddress(networkView, dnsView string, subnet netip.Prefix, hostname string, logger logr.Logger) error
 	// CheckNetworkViewExists checks if Infoblox network view exists
 	CheckNetworkViewExists(view string) (bool, error)
+	// CheckDnsViewExists checks if Infoblox DNS view exists
+	CheckDnsViewExists(view string) (bool, error)
 	// CheckNetworkExists checks if Infoblox network exists
 	CheckNetworkExists(view string, subnet netip.Prefix) (bool, error)
 	GetHostConfig() *HostConfig
@@ -58,6 +60,7 @@ type HostConfig struct {
 	DisableTLSVerification bool
 	CustomCAPath           string
 	DefaultNetworkView     string
+	DefaultDnsView         string
 }
 
 // Config is a wrapper config structures.
@@ -127,6 +130,17 @@ func AuthConfigFromSecretData(data map[string][]byte) (AuthConfig, error) {
 
 func (c *client) CheckNetworkViewExists(view string) (bool, error) {
 	_, err := c.objMgr.GetNetworkView(view)
+	if err != nil {
+		if isNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (c *client) CheckDnsViewExists(view string) (bool, error) {
+	_, err := c.objMgr.GetDNSView(view)
 	if err != nil {
 		if isNotFound(err) {
 			return false, nil

--- a/pkg/infoblox/ibmock/client.go
+++ b/pkg/infoblox/ibmock/client.go
@@ -42,6 +42,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// CheckDnsViewExists mocks base method.
+func (m *MockClient) CheckDnsViewExists(view string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckDnsViewExists", view)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckDnsViewExists indicates an expected call of CheckDnsViewExists.
+func (mr *MockClientMockRecorder) CheckDnsViewExists(view any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDnsViewExists", reflect.TypeOf((*MockClient)(nil).CheckDnsViewExists), view)
+}
+
 // CheckNetworkExists mocks base method.
 func (m *MockClient) CheckNetworkExists(view string, subnet netip.Prefix) (bool, error) {
 	m.ctrl.T.Helper()
@@ -87,30 +102,30 @@ func (mr *MockClientMockRecorder) GetHostConfig() *gomock.Call {
 }
 
 // GetOrAllocateAddress mocks base method.
-func (m *MockClient) GetOrAllocateAddress(view string, subnet netip.Prefix, hostname, zone string, logger logr.Logger) (netip.Addr, error) {
+func (m *MockClient) GetOrAllocateAddress(networkView, dnsView string, subnet netip.Prefix, hostname, zone string, logger logr.Logger) (netip.Addr, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrAllocateAddress", view, subnet, hostname, zone, logger)
+	ret := m.ctrl.Call(m, "GetOrAllocateAddress", networkView, dnsView, subnet, hostname, zone, logger)
 	ret0, _ := ret[0].(netip.Addr)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOrAllocateAddress indicates an expected call of GetOrAllocateAddress.
-func (mr *MockClientMockRecorder) GetOrAllocateAddress(view, subnet, hostname, zone, logger any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetOrAllocateAddress(networkView, dnsView, subnet, hostname, zone, logger any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrAllocateAddress", reflect.TypeOf((*MockClient)(nil).GetOrAllocateAddress), view, subnet, hostname, zone, logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrAllocateAddress", reflect.TypeOf((*MockClient)(nil).GetOrAllocateAddress), networkView, dnsView, subnet, hostname, zone, logger)
 }
 
 // ReleaseAddress mocks base method.
-func (m *MockClient) ReleaseAddress(view string, subnet netip.Prefix, hostname string, logger logr.Logger) error {
+func (m *MockClient) ReleaseAddress(networkView, dnsView string, subnet netip.Prefix, hostname string, logger logr.Logger) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReleaseAddress", view, subnet, hostname, logger)
+	ret := m.ctrl.Call(m, "ReleaseAddress", networkView, dnsView, subnet, hostname, logger)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReleaseAddress indicates an expected call of ReleaseAddress.
-func (mr *MockClientMockRecorder) ReleaseAddress(view, subnet, hostname, logger any) *gomock.Call {
+func (mr *MockClientMockRecorder) ReleaseAddress(networkView, dnsView, subnet, hostname, logger any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseAddress", reflect.TypeOf((*MockClient)(nil).ReleaseAddress), view, subnet, hostname, logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseAddress", reflect.TypeOf((*MockClient)(nil).ReleaseAddress), networkView, dnsView, subnet, hostname, logger)
 }


### PR DESCRIPTION
As discussed in [this issue](https://github.com/telekom/cluster-api-ipam-provider-infoblox/issues/82), I changed the code to make the DNS view customizable by the users.
The changes have been made using AI as I failed to do it myself.
I was able to successfully deploy and use this version in my env and it worked as expected. I still have to test that the default behavior (adding the "default" prefix) has not been changed.