### PR TITLE
Fix defaultDNSView not working

### DIFF
--- a/internal/controllers/util.go
+++ b/internal/controllers/util.go
@@ -32,6 +32,7 @@ func getInfobloxClientForInstance(ctx context.Context, client client.Reader, nam
 			Version:                instance.Spec.WAPIVersion,
 			DisableTLSVerification: instance.Spec.DisableTLSVerification,
 			DefaultNetworkView:     instance.Spec.DefaultNetworkView,
+			DefaultDNSView:         instance.Spec.DefaultDNSView,
 		},
 		AuthConfig: ac,
 	}


### PR DESCRIPTION
I realized I was using the dnsView property in the InfobloxIPPool spec so I did not test defaultDNSView, sorry for that. After testing it realized it was not working as expected and not propagated.