### PR TITLE
fix: add docker-licenses target to generate licenses at stable path for Docker build

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           go-version: '^1.25'
 
-      - name: Create Licenses Report
+      - name: Create Docker Licenses Report
         run: make docker-licenses
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -30,7 +30,7 @@ jobs:
           go-version: '^1.25'
 
       - name: Create Licenses Report
-        run: make licenses-report
+        run: make docker-licenses
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3.6.0

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: test licenses-report ## Build docker image with the manager.
+docker-build: test docker-licenses ## Build docker image with the manager.
 	docker build --platform ${TARGETPLATFORM}  -t ${IMG} .
 
 .PHONY: docker-push
@@ -136,6 +136,15 @@ licenses-report: go-licenses
 	$(GO_LICENSES) save --save_path $(RELEASE_DIR)/licenses ./...
 	$(GO_LICENSES) report --template hack/licenses.md.tpl ./... > $(RELEASE_DIR)/licenses/licenses.md
 	(cd $(RELEASE_DIR)/licenses && tar -czf ../licenses.tar.gz *)
+
+# Docker-specific license collection: saves to a stable, non-versioned path
+# that matches the COPY instruction in the Dockerfile.
+DOCKER_LICENSES_DIR = out/ipam-infoblox/licenses
+.PHONY: docker-licenses
+docker-licenses: go-licenses ## Collect dependency licenses for the Docker image build.
+	rm -rf $(DOCKER_LICENSES_DIR)
+	$(GO_LICENSES) save --save_path $(DOCKER_LICENSES_DIR) ./...
+	$(GO_LICENSES) report --template hack/licenses.md.tpl ./... > $(DOCKER_LICENSES_DIR)/licenses.md
 
 ##@ Release Utils
 


### PR DESCRIPTION
## Summary

Fixes the Docker image build failure caused by a path mismatch between the license collection step and the Dockerfile's `COPY` instruction.

## Root Cause

The `build-image.yaml` workflow ran `make licenses-report` before `docker build`. The `licenses-report` target saves dependency licenses to a **versioned path**:

```
out/ipam-infoblox/<RELEASE_TAG>/licenses/
# e.g. out/ipam-infoblox/v0.2.0/licenses/
```

However, the `Dockerfile` expects licenses at a **non-versioned, stable path**:

```dockerfile
COPY out/ipam-infoblox/licenses /licenses
```

This mismatch caused the Docker build to fail with:
```
COPY failed: '/out/licenses': not found
```

## Fix

Add a dedicated `docker-licenses` make target that collects dependency licenses to the stable, non-versioned path `out/ipam-infoblox/licenses/` that the Dockerfile expects:

```makefile
DOCKER_LICENSES_DIR = out/ipam-infoblox/licenses
.PHONY: docker-licenses
docker-licenses: go-licenses ## Collect dependency licenses for the Docker image build.
	rm -rf $(DOCKER_LICENSES_DIR)
	$(GO_LICENSES) save --save_path $(DOCKER_LICENSES_DIR) ./...
	$(GO_LICENSES) report --template hack/licenses.md.tpl ./... > $(DOCKER_LICENSES_DIR)/licenses.md
```

Update `build-image.yaml` to call `make docker-licenses` instead of `make licenses-report`, and update the `docker-build` Makefile target accordingly.

The existing `licenses-report` target is **unchanged** — it continues to produce the versioned output needed by the release workflow.

## Testing

- `make docker-licenses` tested locally — generates licenses at `out/ipam-infoblox/licenses/`
- `docker build` with the generated licenses succeeds — `COPY out/ipam-infoblox/licenses /licenses` passes
- `licenses-report` target continues to work for the release workflow (no changes)