### PR TITLE
Improve IP-Pool validation and usage transparency

### DIFF
--- a/api/v1alpha1/infobloxippool_types.go
+++ b/api/v1alpha1/infobloxippool_types.go
@@ -69,6 +69,9 @@ type Subnet struct {
 type InfobloxIPPoolStatus struct {
 	// +kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitzero"`
+
+	// +kubebuilder:validation:Optional
+	ClaimedIPs int `json:"claimedIPs,omitzero"`
 }
 
 // InfobloxIPPool is the Schema for the InfobloxIPPools API.
@@ -78,6 +81,7 @@ type InfobloxIPPoolStatus struct {
 // +kubebuilder:printcolumn:name="Network view",type="string",JSONPath=".spec.networkView",description="Default network view"
 // +kubebuilder:printcolumn:name="Subnets",type="string",JSONPath=".spec.subnets",description="Subnets to allocate IPs from"
 // +kubebuilder:printcolumn:name="DNSZone",type="string",JSONPath=".spec.dnsZone",description="The DNS zone within which hostnames will be allocated"
+// +kubebuilder:printcolumn:name="ClaimedIPs",type="string",JSONPath=".status.claimedIPs",description="The Amount of IPs claimed in the pools Subnets"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:printcolumn:name="Deleted",type=date,JSONPath=`.metadata.deletionTimestamp`,priority=1
 type InfobloxIPPool struct {

--- a/api/v1alpha1/infobloxippool_types.go
+++ b/api/v1alpha1/infobloxippool_types.go
@@ -15,6 +15,8 @@ type InfobloxIPPoolSpec struct {
 	// Subnets is the subnet to assign IP addresses from.
 	// Can be omitted if addresses or first, last and prefix are set.
 	//
+	// +listType=map
+	// +listMapKey=cidr
 	// +kubebuilder:validation:Required
 	Subnets []Subnet `json:"subnets,omitzero"`
 
@@ -44,24 +46,29 @@ type InstanceReference struct {
 	Name string `json:"name,omitzero"`
 }
 
-// InfobloxIPPoolStatus defines the observed state of InfobloxIPPool.
-type InfobloxIPPoolStatus struct {
-	// +kubebuilder:validation:Optional
-	Conditions []metav1.Condition `json:"conditions,omitzero"`
-}
-
 // Subnet defines the CIDR and Gateway.
 type Subnet struct {
 
 	// CIDR for the subnet.
 	//
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=43
+	// +kubebuilder:validation:Pattern=`^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$|^[0-9a-fA-F:]+/[0-9]{1,3}$`
 	CIDR string `json:"cidr,omitzero"`
 
 	// Gateway for the subnet.
 	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxLength=39
+	// +kubebuilder:validation:Pattern=`^$|^([0-9]{1,3}\.){3}[0-9]{1,3}$|^[0-9a-fA-F:]+$`
 	Gateway string `json:"gateway,omitzero"`
+}
+
+// InfobloxIPPoolStatus defines the observed state of InfobloxIPPool.
+type InfobloxIPPoolStatus struct {
+	// +kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitzero"`
 }
 
 // InfobloxIPPool is the Schema for the InfobloxIPPools API.

--- a/config/crd/bases/ipam.cluster.x-k8s.io_infobloxippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_infobloxippools.yaml
@@ -89,14 +89,22 @@ spec:
                   properties:
                     cidr:
                       description: CIDR for the subnet.
+                      maxLength: 43
+                      minLength: 1
+                      pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$|^[0-9a-fA-F:]+/[0-9]{1,3}$
                       type: string
                     gateway:
                       description: Gateway for the subnet.
+                      maxLength: 39
+                      pattern: ^$|^([0-9]{1,3}\.){3}[0-9]{1,3}$|^[0-9a-fA-F:]+$
                       type: string
                   required:
                   - cidr
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - cidr
+                x-kubernetes-list-type: map
             required:
             - instance
             - subnets

--- a/config/crd/bases/ipam.cluster.x-k8s.io_infobloxippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_infobloxippools.yaml
@@ -27,6 +27,10 @@ spec:
       jsonPath: .spec.dnsZone
       name: DNSZone
       type: string
+    - description: The Amount of IPs claimed in the pools Subnets
+      jsonPath: .status.claimedIPs
+      name: ClaimedIPs
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -112,6 +116,8 @@ spec:
           status:
             description: InfobloxIPPoolStatus defines the observed state of InfobloxIPPool.
             properties:
+              claimedIPs:
+                type: integer
               conditions:
                 items:
                   description: Condition contains details for one aspect of the current

--- a/internal/controllers/infobloxippool.go
+++ b/internal/controllers/infobloxippool.go
@@ -95,27 +95,29 @@ func (r *InfobloxIPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	// remove finalizer if no claims point to this pool anymore
+	poolTypeRef := ipamv1.IPPoolReference{
+		APIGroup: pool.GetObjectKind().GroupVersionKind().Group,
+		Kind:     pool.GetObjectKind().GroupVersionKind().Kind,
+		Name:     pool.GetName(),
+	}
+	inUseClaims, err := poolutil.ListClaimsReferencingPool(ctx, r.Client, pool.GetNamespace(), poolTypeRef)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	pool.Status.ClaimedIPs = len(inUseClaims)
+
 	if isMarkedForDeletion {
-		poolTypeRef := ipamv1.IPPoolReference{
-			APIGroup: pool.GetObjectKind().GroupVersionKind().Group,
-			Kind:     pool.GetObjectKind().GroupVersionKind().Kind,
-			Name:     pool.GetName(),
-		}
-		inUseClaims, err := poolutil.ListClaimsReferencingPool(ctx, r.Client, pool.GetNamespace(), poolTypeRef)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
 		for _, claim := range inUseClaims {
-			logger.Info("still found claim in use", "claim", claim.Name)
+			logger.Info("found claim still in use", "claim", claim.Name)
 		}
-		if len(inUseClaims) == 0 {
-			if controllerutil.RemoveFinalizer(pool, ProtectPoolFinalizer) {
-				return ctrl.Result{}, nil
-			}
-			return ctrl.Result{}, nil
+		if len(inUseClaims) > 0 {
+			return ctrl.Result{}, fmt.Errorf(
+				"pool has %d IPAddresses or IPAddressClaims allocated."+
+					"Cannot delete Pool until all IPAddresses and IPAddressClaims have been removed", len(inUseClaims))
 		}
-		return ctrl.Result{}, fmt.Errorf("pool has IPAddresses or IPAddressClaims allocated. Cannot delete Pool until all IPAddresses and IPAddressClaims have been removed")
+		// remove finalizer if no claims point to this pool anymore
+		controllerutil.RemoveFinalizer(pool, ProtectPoolFinalizer)
+		return ctrl.Result{}, nil
 	}
 
 	return ctrl.Result{}, r.reconcile(ctx, pool)

--- a/internal/controllers/infobloxippool_validation_test.go
+++ b/internal/controllers/infobloxippool_validation_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/telekom/cluster-api-ipam-provider-infoblox/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("InfobloxIPPool CRD validation", func() {
+	validPool := func(name string, subnets []v1alpha1.Subnet) *v1alpha1.InfobloxIPPool {
+		return &v1alpha1.InfobloxIPPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+			},
+			Spec: v1alpha1.InfobloxIPPoolSpec{
+				InstanceRef: v1alpha1.InstanceReference{Name: "test-instance"},
+				Subnets:     subnets,
+			},
+		}
+	}
+
+	Context("CIDR validation", func() {
+		It("should accept a valid IPv4 CIDR", func() {
+			pool := validPool("valid-v4-cidr", []v1alpha1.Subnet{{CIDR: "10.0.0.0/24", Gateway: "10.0.0.1"}})
+			Expect(poolCreateAndDelete(ctx, k8sClient, pool)).To(Succeed())
+		})
+
+		It("should accept a valid IPv6 CIDR", func() {
+			pool := validPool("valid-v6-cidr", []v1alpha1.Subnet{{CIDR: "2001:db8::/64", Gateway: "2001:db8::1"}})
+			Expect(poolCreateAndDelete(ctx, k8sClient, pool)).To(Succeed())
+		})
+
+		It("should reject a non-CIDR string", func() {
+			pool := validPool("invalid-cidr", []v1alpha1.Subnet{{CIDR: "not-a-cidr"}})
+			err := poolCreateAndDelete(ctx, k8sClient, pool)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.subnets[0].cidr"))
+			Expect(err.Error()).To(ContainSubstring("Invalid value"))
+		})
+
+		It("should reject a CIDR without prefix", func() {
+			pool := validPool("no-prefix-cidr", []v1alpha1.Subnet{{CIDR: "10.0.0.0"}})
+			err := poolCreateAndDelete(ctx, k8sClient, pool)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.subnets[0].cidr"))
+			Expect(err.Error()).To(ContainSubstring("Invalid value"))
+		})
+
+		It("should reject an empty CIDR", func() {
+			pool := validPool("empty-cidr", []v1alpha1.Subnet{{CIDR: ""}})
+			err := poolCreateAndDelete(ctx, k8sClient, pool)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.subnets"))
+		})
+	})
+
+	Context("Gateway validation", func() {
+		It("should accept a valid IPv4 gateway", func() {
+			pool := validPool("valid-v4-gw", []v1alpha1.Subnet{{CIDR: "10.0.0.0/24", Gateway: "10.0.0.1"}})
+			Expect(poolCreateAndDelete(ctx, k8sClient, pool)).To(Succeed())
+		})
+
+		It("should accept a valid IPv6 gateway", func() {
+			pool := validPool("valid-v6-gw", []v1alpha1.Subnet{{CIDR: "2001:db8::/64", Gateway: "2001:db8::1"}})
+			Expect(poolCreateAndDelete(ctx, k8sClient, pool)).To(Succeed())
+		})
+
+		It("should accept an empty gateway", func() {
+			pool := validPool("empty-gw", []v1alpha1.Subnet{{CIDR: "10.0.0.0/24", Gateway: ""}})
+			Expect(poolCreateAndDelete(ctx, k8sClient, pool)).To(Succeed())
+		})
+
+		It("should reject a non-IP gateway", func() {
+			pool := validPool("invalid-gw", []v1alpha1.Subnet{{CIDR: "10.0.0.0/24", Gateway: "not-an-ip"}})
+			err := poolCreateAndDelete(ctx, k8sClient, pool)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.subnets[0].gateway"))
+			Expect(err.Error()).To(ContainSubstring("Invalid value"))
+		})
+
+		It("should reject a gateway with CIDR notation", func() {
+			pool := validPool("cidr-gw", []v1alpha1.Subnet{{CIDR: "10.0.0.0/24", Gateway: "10.0.0.1/24"}})
+			err := poolCreateAndDelete(ctx, k8sClient, pool)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.subnets[0].gateway"))
+			Expect(err.Error()).To(ContainSubstring("Invalid value"))
+		})
+	})
+
+	Context("Subnet uniqueness (listType=map)", func() {
+		It("should accept multiple subnets with different CIDRs", func() {
+			pool := validPool("unique-subnets", []v1alpha1.Subnet{
+				{CIDR: "10.0.0.0/24", Gateway: "10.0.0.1"},
+				{CIDR: "10.0.1.0/24", Gateway: "10.0.1.1"},
+			})
+			Expect(poolCreateAndDelete(ctx, k8sClient, pool)).To(Succeed())
+		})
+
+		It("should reject duplicate subnet CIDRs", func() {
+			pool := validPool("dup-subnets", []v1alpha1.Subnet{
+				{CIDR: "10.0.0.0/24", Gateway: "10.0.0.1"},
+				{CIDR: "10.0.0.0/24", Gateway: "10.0.0.2"},
+			})
+			err := poolCreateAndDelete(ctx, k8sClient, pool)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Duplicate"))
+		})
+	})
+})
+
+func poolCreateAndDelete(ctx context.Context, cl client.Client, obj client.Object) error {
+	defer cl.Delete(ctx, obj) //nolint:errcheck
+	return cl.Create(ctx, obj)
+}


### PR DESCRIPTION
1. Improve the validation on IPPool Subnet resources to
  - List may only contain unique CIDR values
  - CIDR and Gateway values must pass basic IPv4/6 validation regex
2. IPPool status now reports the amount of IPAddress(Claims) bound to it so one has an idea how many addresses are claimed in the Pool at a given time.