### PR TITLE
ci: derive Go version from go.mod

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '^1.25'
+          go-version-file: go.mod
 
       - name: Create Docker Licenses Report
         run: make docker-licenses

--- a/.github/workflows/draft_release.yaml
+++ b/.github/workflows/draft_release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '^1.24'
+          go-version-file: go.mod
       - name: Create Release Artifacts
         run: make release
       - name: Create Release

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -15,11 +15,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.25
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9.0.0
         with:
           version: v2.2.1
+          install-mode: goinstall
 
   test:
     name: test
@@ -28,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.25
+          go-version-file: go.mod
       - name: Run Tests
         run: make test
 
@@ -39,7 +40,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.25
+          go-version-file: go.mod
       - name: run code generators
         run: make generate
       - name: run manifest generators


### PR DESCRIPTION
## Summary
- use `go-version-file: go.mod` in PR, release, and image workflows
- build the pinned `golangci-lint` v2.2.1 with the workflow Go toolchain via `install-mode: goinstall`
- remove hard-coded Go minor versions from CI setup

## CI failure addressed
- Addresses the PR #154 failures where the dependabot update targets Go 1.26.2 but CI installs Go 1.25 for tests/generation.
- Addresses the lint failure where the prebuilt `golangci-lint` v2.2.1 binary was built with a Go version older than the target Go version.

## Validation
- Parsed the edited workflow YAML with Ruby `YAML.load_file`.
- `actionlint` is not installed in this environment, so I could not run it locally.
